### PR TITLE
Improve export 

### DIFF
--- a/jpyltime/app.py
+++ b/jpyltime/app.py
@@ -56,6 +56,7 @@ def fhir2dataset_route(
 
     # postprocessing
     df = FHIR2DS_Postprocessing(updated_map_attributes).postprocess(sql_df, requested_attributes)
+    print(df)
     response = StreamingResponse(io.StringIO(df.to_csv(index=False)), media_type="text/csv")
     response.headers["Content-Disposition"] = "attachment; filename=export.csv"
 

--- a/jpyltime/documents/attributes_mapping.json
+++ b/jpyltime/documents/attributes_mapping.json
@@ -70,7 +70,7 @@
         },
         "display": {
             "concatenate_columns": ["Condition.code.coding.code", "Condition.code.coding.display"],
-            "join_symbol": "( )"
+            "join_symbol": " "
         }
     },
     "Medication": {

--- a/jpyltime/documents/attributes_mapping.json
+++ b/jpyltime/documents/attributes_mapping.json
@@ -70,7 +70,7 @@
         },
         "display": {
             "concatenate_columns": ["Condition.code.coding.code", "Condition.code.coding.display"],
-            "join_symbol": " "
+            "join_symbol": ": "
         }
     },
     "Medication": {

--- a/jpyltime/postprocessing_fhir2ds.py
+++ b/jpyltime/postprocessing_fhir2ds.py
@@ -14,7 +14,7 @@ class FHIR2DS_Postprocessing:
 
     def _groupby_patient_column(self, df: pd.DataFrame, patient_columns: List[str]) -> pd.DataFrame:
         """Groupby Patient and combine other values as list of the same type (ex. Weight or Potassium)"""
-        # Aggregate information by Patient, dropping null values to avoid NaN in output list
+        # Aggregate information by Patient, dropping null values to avoid Null in output list, ex [50kg, Null, Null, Null, 60kg, Null, 80kg, Null]
         return (
             df.groupby(patient_columns, dropna=False)
             .agg(lambda x: list(x[x.notna()]))

--- a/jpyltime/postprocessing_fhir2ds.py
+++ b/jpyltime/postprocessing_fhir2ds.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 
@@ -12,41 +12,49 @@ class FHIR2DS_Postprocessing:
         self.map_attributes = map_attributes
         self.anonymization_symbol = anonymization_symbol
 
-    def _groupby_one_column(self, df: pd.DataFrame, col_for_merging: str) -> pd.DataFrame:
-        """Groupby one column (arg. col_for_merging) and combine the grouped rows in list, keeping only not null value
-        Check that the column selected to apply the groupby exists in the dataFrame, overwise raise an Exception."""
+    def _groupby_one_column(
+        self, df: pd.DataFrame, col_for_merging: str, col_from_patient_table: Dict[str, bool]
+    ) -> pd.DataFrame:
+        """Groupby one column (arg. col_for_merging), then either:
+            - keep only one value for column from main table (Patient), to avoid repetition of similar value (ex. Name)
+            - combine other values as list of the same type (ex. Weight or Potassium)
+        Check that the column selected to apply the groupby exists in the dataFrame, overwise raise an Exception.
+        Remove patient index column coming from FHIR resource and reset new index"""
         if col_for_merging not in df.columns:
             raise Exception(
                 f"Impossible to merge on column name {col_for_merging} as it is not present in the dataframe: {df.columns}"
             )
-        # FIXME: Avoid multiple similar values by removing duplicates and returning eiter element or list.
-        # Correct way should be :
-        #   - to keep only one value for column coming from main table (ie Patient here)
-        #   - and returning list (without duplicates removal) for columns from other tables (to keep values and temporality)
-        def reduce(x):
-            x = set(x[x.notna()])
-            if not x:
-                return None
-            if len(x) == 1:
-                return next(iter(x))
-            return list(x)
-
-        return df.groupby(by=[col_for_merging]).agg(lambda x: reduce(x)).reset_index()
+        df = df.groupby(by=[col_for_merging]).agg(lambda x: list(x[x.notna()])).reset_index()
+        df.drop(columns=[col_for_merging], inplace=True)
+        for col in df.columns:
+            if col_from_patient_table[col]:
+                df[col] = df[col].apply(lambda x: x[0] if x else None)
+        return df
 
     def _concatenate_columns(
-        self, df: pd.DataFrame, attributes: Dict[str, Attribute], patient_id_colname: str
-    ) -> pd.DataFrame:
+        self,
+        df: pd.DataFrame,
+        attributes: Dict[str, Attribute],
+        patient_id_colname: str,
+        patient_resource_name: str = "Patient",
+    ) -> Tuple[pd.DataFrame, Dict[str, bool]]:
         """To improve readibility and display, some columns are gathered to reduce the complexity of the dataFrame.
             Display info are written in the attribute dictionary and the dataFrame is modified according to the instructions, by combining some columns.
             Ex: combine value with quantity improve readibility:
                 --  | patient.weight.value : 30 | patient.weight.unit : kg |
                 ++  | Weight : 30 kg |
             Replace col name with custom name
+            Keep tracks of columns coming from main resource table (Patient)
 
         Args:
             df: DataFrame as outputted by FHIR2Dataset api
             attributes: Dict of attributes asked by user, with info on anonymization constraints and custom names
+            patient_id_colname: Name of the column for patient index in FHIR
+            patient_resource_name: Name of main table, Patient resource in FHIR
 
+        Return:
+            display_df: df with improved readibility
+            col_from_patient_table: dictionary to know if a column in display_df belongs to the main table Patient or not
         """
 
         def flatten(x):
@@ -54,6 +62,7 @@ class FHIR2DS_Postprocessing:
 
         display_df = pd.DataFrame()
         display_df[patient_id_colname] = df[patient_id_colname]
+        col_from_patient_table: Dict[str, bool] = {}
         # Fill the new dataset with : new column names and combination of some column values
         for attribute in attributes.values():
             attribute_info = self.map_attributes[attribute.official_name]
@@ -67,12 +76,16 @@ class FHIR2DS_Postprocessing:
                     ),
                     axis=1,
                 )
+                col_from_patient_table[attribute.custom_name] = False
             # Case only renaming is required
             else:
                 display_df[attribute.custom_name] = df[
                     attribute_info["fhir_source"]["select"][0]
                 ].apply(lambda x: flatten(x)[0])
-        return display_df
+                col_from_patient_table[attribute.custom_name] = (
+                    attribute_info["fhir_resource"] == patient_resource_name
+                )
+        return display_df, col_from_patient_table
 
     def anonymize(self, df: pd.DataFrame, attributes: Dict[str, Attribute]) -> pd.DataFrame:
         """Anonymize columns by replacing value with a symbol"""
@@ -99,8 +112,9 @@ class FHIR2DS_Postprocessing:
         Returns:
             pd.DataFrame: The dataFrame updated with the previous transformation.
         """
-        df = self._concatenate_columns(df, attributes, patient_index)
-        df = self._groupby_one_column(df, col_for_merging=patient_index)
+        df, col_from_patient_table = self._concatenate_columns(df, attributes, patient_index)
+        df = self._groupby_one_column(
+            df, col_for_merging=patient_index, col_from_patient_table=col_from_patient_table
+        )
         df = self.anonymize(df, attributes)
-        df.drop(columns=[patient_index], inplace=True)
         return df.reset_index(drop=True)

--- a/jpyltime/postprocessing_fhir2ds.py
+++ b/jpyltime/postprocessing_fhir2ds.py
@@ -90,4 +90,5 @@ class FHIR2DS_Postprocessing:
         df = self._concatenate_columns(df, attributes, patient_index)
         df = self._groupby_one_column(df, col_for_merging=patient_index)
         df = self.anonymize(df, attributes)
+        df.drop(columns=[patient_index], inplace=True)
         return df.reset_index(drop=True)

--- a/jpyltime/postprocessing_fhir2ds.py
+++ b/jpyltime/postprocessing_fhir2ds.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 
 import pandas as pd
 
@@ -90,13 +90,11 @@ class FHIR2DS_Postprocessing:
         """
         df = self._concatenate_columns(df, attributes, patient_index)
         # Construct the list of columns coming from the main table, Patient"""
-        patient_columns: List[str] = [patient_index]
-        for attribute in attributes.values():
-            if (
-                self.map_attributes[attribute.official_name]["fhir_resource"]
-                == patient_resource_name
-            ):
-                patient_columns.append(attribute.custom_name)
+        patient_columns: List[str] = [
+            attr.custom_name
+            for attr in attributes.values()
+            if self.map_attributes[attr.official_name]["fhir_resource"] == patient_resource_name
+        ] + [patient_index]
         # Groupby Patient and combine other values as list of the same type (ex. Weight or Potassium)"""
         # Aggregate information by Patient, dropping null values to avoid Null in output list, ex [50kg, Null, Null, Null, 60kg, Null, 80kg, Null]
         df = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,10 @@ def client():
 @pytest.fixture
 def attributes():
     attributes = [
-        Attribute(official_name="First name", custom_name="Prénom", anonymize=False),
+        Attribute(official_name="First name", custom_name="Prénom", anonymize=True),
         Attribute(official_name="Weight", custom_name="Poids", anonymize=False),
         Attribute(official_name="Medication", custom_name="Médicaments", anonymize=False),
-        Attribute(official_name="Birthdate", custom_name="Anniversaire", anonymize=True),
+        Attribute(official_name="Birthdate", custom_name="Anniversaire", anonymize=False),
     ]
     requested_attributes = {attribute.official_name: attribute for attribute in attributes}
     return requested_attributes

--- a/tests/postprocessing_test.py
+++ b/tests/postprocessing_test.py
@@ -49,12 +49,12 @@ def test_postprocessing(map_attributes, example_dataframe, attributes):
     )
     display_df = postprocessing.postprocess(example_dataframe, attributes)
 
-    true_columns = ["Patient:from_id", "Prénom", "Poids", "Médicaments", "Anniversaire"]
+    true_columns = ["Prénom", "Poids", "Médicaments", "Anniversaire"]
     true = pd.DataFrame(
         [
-            ["3728", {"john"}, {"20 kg"}, {"ICD 22 mg"}, "*"],
-            ["8392", {"tom", "nick"}, {"50 kg", "90 kg"}, {"ICD 8493 L", "ICD 22 mg"}, "*"],
-            ["9382", {"julie"}, {"92 kg"}, {"ICD 38 L"}, "*"],
+            ["*", "20 kg", "ICD 22 mg", None],
+            ["*", ["50 kg", "90 kg"], ["ICD 8493 L", "ICD 22 mg"], "2019-20-20"],
+            ["*", "92 kg", "ICD 38 L", None],
         ],
         columns=true_columns,
     )

--- a/tests/postprocessing_test.py
+++ b/tests/postprocessing_test.py
@@ -52,9 +52,14 @@ def test_postprocessing(map_attributes, example_dataframe, attributes):
     true_columns = ["Prénom", "Poids", "Médicaments", "Anniversaire"]
     true = pd.DataFrame(
         [
-            ["*", "20 kg", "ICD 22 mg", None],
-            ["*", ["50 kg", "90 kg"], ["ICD 8493 L", "ICD 22 mg"], "2019-20-20"],
-            ["*", "92 kg", "ICD 38 L", None],
+            ["*", ["20 kg"], ["ICD 22 mg"], None],
+            [
+                "*",
+                ["50 kg", "50 kg", "90 kg"],
+                ["ICD 22 mg", "ICD 8493 L", "ICD 22 mg"],
+                "2019-20-20",
+            ],
+            ["*", ["92 kg"], ["ICD 38 L"], None],
         ],
         columns=true_columns,
     )

--- a/tests/postprocessing_test.py
+++ b/tests/postprocessing_test.py
@@ -51,10 +51,10 @@ def test_postprocessing(map_attributes, example_dataframe, attributes):
     expected_columns = ["Prénom", "Anniversaire", "Poids", "Médicaments"]
     expected = pd.DataFrame(
         [
-            ["*", "2019-03-23", ["90 kg"], ["ICD 22 mg"]],
             ["*", "2839-11-20", ["20 kg"], ["ICD 22 mg"]],
-            ["*", "2019-20-20", ["50 kg", "50 kg"], ["ICD 22 mg", "ICD 8493 L"]],
             ["*", "1300-05-17", ["92 kg"], ["ICD 38 L"]],
+            ["*", "2019-03-23", ["90 kg"], ["ICD 22 mg"]],
+            ["*", "2019-20-20", ["50 kg", "50 kg"], ["ICD 22 mg", "ICD 8493 L"]],
         ],
         columns=expected_columns,
     )

--- a/tests/postprocessing_test.py
+++ b/tests/postprocessing_test.py
@@ -19,10 +19,10 @@ def map_attributes():
 def example_dataframe():
     data = [
         ["8392", "tom", 10, "ICD", 22, "mg", 50, "kg", "2019-20-20"],
-        ["8392", "tom", 1, "ICD", 8493, "L", 50, "kg"],
-        ["8392", "nick", 10, "ICD", 22, "mg", 90, "kg"],
-        ["9382", "julie", 1, "ICD", 38, "L", 92, "kg"],
-        ["3728", "john", 10, "ICD", 22, "mg", 20, "kg"],
+        ["8392", "tom", 1, "ICD", 8493, "L", 50, "kg", "2019-20-20"],
+        ["2038", "nick", 10, "ICD", 22, "mg", 90, "kg", "2019-03-23"],
+        ["9382", "julie", 1, "ICD", 38, "L", 92, "kg", "1300-05-17"],
+        ["3728", "john", 10, "ICD", 22, "mg", 20, "kg", "2839-11-20"],
     ]
     # Create the pandas DataFrame
     df = pd.DataFrame(
@@ -48,20 +48,15 @@ def test_postprocessing(map_attributes, example_dataframe, attributes):
         map_attributes, anonymization_symbol=anonymization_symbol
     )
     display_df = postprocessing.postprocess(example_dataframe, attributes)
-
-    true_columns = ["Prénom", "Poids", "Médicaments", "Anniversaire"]
-    true = pd.DataFrame(
+    expected_columns = ["Prénom", "Anniversaire", "Poids", "Médicaments"]
+    expected = pd.DataFrame(
         [
-            ["*", ["20 kg"], ["ICD 22 mg"], None],
-            [
-                "*",
-                ["50 kg", "50 kg", "90 kg"],
-                ["ICD 22 mg", "ICD 8493 L", "ICD 22 mg"],
-                "2019-20-20",
-            ],
-            ["*", ["92 kg"], ["ICD 38 L"], None],
+            ["*", "2019-03-23", ["90 kg"], ["ICD 22 mg"]],
+            ["*", "2839-11-20", ["20 kg"], ["ICD 22 mg"]],
+            ["*", "2019-20-20", ["50 kg", "50 kg"], ["ICD 22 mg", "ICD 8493 L"]],
+            ["*", "1300-05-17", ["92 kg"], ["ICD 38 L"]],
         ],
-        columns=true_columns,
+        columns=expected_columns,
     )
 
-    assert true.equals(display_df)
+    assert expected.equals(display_df)

--- a/tests/postprocessing_test.py
+++ b/tests/postprocessing_test.py
@@ -51,10 +51,10 @@ def test_postprocessing(map_attributes, example_dataframe, attributes):
     expected_columns = ["Prénom", "Anniversaire", "Poids", "Médicaments"]
     expected = pd.DataFrame(
         [
-            ["*", "2839-11-20", ["20 kg"], ["ICD 22 mg"]],
-            ["*", "1300-05-17", ["92 kg"], ["ICD 38 L"]],
             ["*", "2019-03-23", ["90 kg"], ["ICD 22 mg"]],
+            ["*", "2839-11-20", ["20 kg"], ["ICD 22 mg"]],
             ["*", "2019-20-20", ["50 kg", "50 kg"], ["ICD 22 mg", "ICD 8493 L"]],
+            ["*", "1300-05-17", ["92 kg"], ["ICD 38 L"]],
         ],
         columns=expected_columns,
     )


### PR DESCRIPTION
## Fixes
- Remove `set` from export: keep multiple values as `list` when they come from a resource other than Patient, else keep only one (to avoid multiple similar values, ex. Name)
- Remove `Patient:from_id` column from export, representing patient index in FHIR
- Fix wrong ICD-9 display 

